### PR TITLE
Update sentry to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "composer/installers": "~1.0",
-        "sentry/sentry-laravel": "~2.0"
+        "sentry/sentry-laravel": "~3.0"
     },
     "extra": {
         "installer-name": "sentry"

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -3,3 +3,4 @@
 "2.0.1": "Rebrand to Winter.Sentry"
 "2.1.0": "Upgrade Sentry client to v2 and PHP8 support"
 "2.1.1": "Add sentry release ENV support"
+"2.2.0": "Updated sentry to v3.x"


### PR DESCRIPTION
This PR bumps the sentry version to ~3.0.

I've tested using the debug route and sentry caught the error correctly, however this may need more testing.